### PR TITLE
fix: require resource_group when using existing networking in Azure m…

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -17,8 +17,8 @@ The module supports two modes:
 
 - **`bootstrap`** (default)
   - Creates and configures an internal load balancer, a private endpoint service and the proxy compute.
-  - If networking (VPC/Vnet & subnets **are provided**, the module uses existing networking.
-  - If network IDs are **not provided**, the module creates the necessary networking resources.
+  - If networking (VPC/VNet & subnets) **are provided** along with `resource_group`, the module uses existing networking.
+  - If networking is **not provided**, the module creates the necessary networking resources (including a new resource group if `resource_group` is `null`).
 
 - **`proxy-only`**
   - Requires existing networking, an existing load balancer and private endpoint service

--- a/terraform/azure/README.md
+++ b/terraform/azure/README.md
@@ -24,7 +24,7 @@ module "dbx_proxy" {
 
   # Azure config
   location       = "westeurope"
-  resource_group = "rg-dbx-proxy"  # optional in bootstrap mode
+  resource_group = "rg-dbx-proxy"  # optional in bootstrap mode (required when using existing networking)
   tags           = {}
 
   # dbx-proxy config
@@ -52,7 +52,7 @@ After apply, use the output `load_balancer.private_link_service_alias` when crea
 | Variable | Type | Default | Description |
 |---|---:|---:|---|
 | `location` | `string` | (required) | Azure region to deploy to. |
-| `resource_group` | `string` | `null` | Resource group name. Required in `proxy-only` mode. If `null` in `bootstrap`, a new one is created. |
+| `resource_group` | `string` | `null` | Resource group name. Required when using existing networking (`vnet_name`/`subnet_name`) or in `proxy-only` mode. If `null` in `bootstrap`, a new one is created. |
 | `vnet_name` | `string` | `null` | Existing VNet name. If `null` in `bootstrap`, a new VNet is created. |
 | `subnet_name` | `string` | `null` | Existing subnet name. If empty in `bootstrap`, a new subnet is created. |
 | `vnet_cidr` | `string` | `"10.0.0.0/16"` | VNet CIDR (only used when bootstrapping). |
@@ -94,6 +94,6 @@ Common variables are documented in `terraform/README.md`.
 
 ### Notes for Azure users
 
-- If `resource_group` is provided, it must already exist. If `null` in `bootstrap` mode, a new one is created.
+- `resource_group` is required when using existing networking (`vnet_name`/`subnet_name`), as it is used to look up the VNet and subnet. If `null` in `bootstrap` mode (without existing networking), a new one is created.
 - Multi availability-zone resilience requires a zonal region and `min_capacity >= 2`; the VM scale set balances VMs over the available zones.
 - In Azure a subnet spans multiple availability-zones, therefore a single subnet is sufficient. In `proxy-only` mode, you are responsible to provide a subnet. In `bootstrap` mode, a default subnet is created.

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -11,7 +11,7 @@ variable "location" {
 
 variable "resource_group" {
   type        = string
-  description = "Resource group name. Required in proxy-only mode. If null in bootstrap mode, a new resource group is created."
+  description = "Resource group name. Required when using existing networking (vnet_name/subnet_name) or in proxy-only mode. If null in bootstrap mode, a new resource group is created."
   default     = null
 }
 
@@ -51,12 +51,16 @@ variable "deployment_mode" {
 }
 
 variable "vnet_name" {
-  description = "Name of existing VNet. If null in bootstrap mode, a new VNet is created."
+  description = "Name of existing VNet. If null in bootstrap mode, a new VNet is created. Requires resource_group to be set."
   type        = string
   default     = null
   validation {
     condition     = var.vnet_name == null || var.subnet_name != null
     error_message = "When vnet_name is set, subnet_name must also be provided."
+  }
+  validation {
+    condition     = var.vnet_name == null || var.resource_group != null
+    error_message = "When vnet_name is set, resource_group must also be provided to look up the existing VNet and subnet."
   }
 }
 
@@ -67,7 +71,7 @@ variable "vnet_cidr" {
 }
 
 variable "subnet_name" {
-  description = "Name of existing subnet. If null in bootstrap mode, a new subnet is created."
+  description = "Name of existing subnet. If null in bootstrap mode, a new subnet is created. Requires vnet_name and resource_group to be set."
   type        = string
   default     = null
 }


### PR DESCRIPTION
…odule

When vnet_name/subnet_name are provided without resource_group, the subnet lookup defaults to the bootstrapped resource group, causing a "subnet not found" error. Add validation to enforce resource_group is set when using existing networking, and update variable descriptions for clarity.

Fixes #4