### PR TITLE
feat: add networking_resource_group variable for Azure module

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -17,7 +17,7 @@ The module supports two modes:
 
 - **`bootstrap`** (default)
   - Creates and configures an internal load balancer, a private endpoint service and the proxy compute.
-  - If networking (VPC/VNet & subnets) **are provided** along with `resource_group`, the module uses existing networking.
+  - If networking (VPC/VNet & subnets) **are provided** along with `resource_group` or `networking_resource_group` (Azure), the module uses existing networking. Use `networking_resource_group` when the VNet/subnet reside in a different resource group than the proxy resources.
   - If networking is **not provided**, the module creates the necessary networking resources (including a new resource group if `resource_group` is `null`).
 
 - **`proxy-only`**

--- a/terraform/azure/README.md
+++ b/terraform/azure/README.md
@@ -24,7 +24,8 @@ module "dbx_proxy" {
 
   # Azure config
   location       = "westeurope"
-  resource_group = "rg-dbx-proxy"  # optional in bootstrap mode (required when using existing networking)
+  resource_group            = "rg-dbx-proxy"  # optional in bootstrap mode
+  # networking_resource_group = "rg-networking" # optional, defaults to resource_group. Set if VNet/subnet live in a different RG.
   tags           = {}
 
   # dbx-proxy config
@@ -52,7 +53,8 @@ After apply, use the output `load_balancer.private_link_service_alias` when crea
 | Variable | Type | Default | Description |
 |---|---:|---:|---|
 | `location` | `string` | (required) | Azure region to deploy to. |
-| `resource_group` | `string` | `null` | Resource group name. Required when using existing networking (`vnet_name`/`subnet_name`) or in `proxy-only` mode. If `null` in `bootstrap`, a new one is created. |
+| `resource_group` | `string` | `null` | Resource group name for proxy resources. Required in `proxy-only` mode. If `null` in `bootstrap`, a new one is created. |
+| `networking_resource_group` | `string` | `null` | Resource group where the existing VNet/subnet reside. Defaults to `resource_group` if not set. Required (or `resource_group`) when using existing networking. |
 | `vnet_name` | `string` | `null` | Existing VNet name. If `null` in `bootstrap`, a new VNet is created. |
 | `subnet_name` | `string` | `null` | Existing subnet name. If empty in `bootstrap`, a new subnet is created. |
 | `vnet_cidr` | `string` | `"10.0.0.0/16"` | VNet CIDR (only used when bootstrapping). |
@@ -94,6 +96,6 @@ Common variables are documented in `terraform/README.md`.
 
 ### Notes for Azure users
 
-- `resource_group` is required when using existing networking (`vnet_name`/`subnet_name`), as it is used to look up the VNet and subnet. If `null` in `bootstrap` mode (without existing networking), a new one is created.
+- When using existing networking (`vnet_name`/`subnet_name`), either `resource_group` or `networking_resource_group` must be set for the VNet/subnet lookup. Use `networking_resource_group` when the networking lives in a different resource group than the proxy resources. If `resource_group` is `null` in `bootstrap` mode, a new one is created for the proxy resources.
 - Multi availability-zone resilience requires a zonal region and `min_capacity >= 2`; the VM scale set balances VMs over the available zones.
 - In Azure a subnet spans multiple availability-zones, therefore a single subnet is sufficient. In `proxy-only` mode, you are responsible to provide a subnet. In `bootstrap` mode, a default subnet is created.

--- a/terraform/azure/local.tf
+++ b/terraform/azure/local.tf
@@ -19,6 +19,12 @@ locals {
     : data.azurerm_resource_group.this[0].name
   )
 
+  networking_resource_group = (
+    var.networking_resource_group != null
+    ? var.networking_resource_group
+    : local.resource_group
+  )
+
   subnet_name = module.networking.subnet_name
   subnet_id   = module.networking.subnet_id
   subnet_cidr = module.networking.subnet_cidr

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -17,10 +17,11 @@ module "networking" {
 
   bootstrap_networking = local.bootstrap_networking
 
-  prefix         = local.prefix
-  location       = var.location
-  resource_group = local.resource_group
-  tags           = local.tags
+  prefix                    = local.prefix
+  location                  = var.location
+  resource_group            = local.resource_group
+  networking_resource_group = local.networking_resource_group
+  tags                      = local.tags
 
   vnet_name = var.vnet_name
   vnet_cidr = var.vnet_cidr

--- a/terraform/azure/modules/networking/data.tf
+++ b/terraform/azure/modules/networking/data.tf
@@ -1,6 +1,6 @@
 data "azurerm_subnet" "this" {
   count                = var.bootstrap_networking ? 0 : 1
   name                 = var.subnet_name
-  resource_group_name  = var.resource_group
+  resource_group_name  = var.networking_resource_group
   virtual_network_name = var.vnet_name
 }

--- a/terraform/azure/modules/networking/variables.tf
+++ b/terraform/azure/modules/networking/variables.tf
@@ -9,7 +9,12 @@ variable "location" {
 }
 
 variable "resource_group" {
-  description = "Resource group name."
+  description = "Resource group name for bootstrapped networking resources."
+  type        = string
+}
+
+variable "networking_resource_group" {
+  description = "Resource group name where the existing VNet and subnet reside. Used for data source lookups when not bootstrapping."
   type        = string
 }
 

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -11,7 +11,13 @@ variable "location" {
 
 variable "resource_group" {
   type        = string
-  description = "Resource group name. Required when using existing networking (vnet_name/subnet_name) or in proxy-only mode. If null in bootstrap mode, a new resource group is created."
+  description = "Resource group name for proxy resources. Required in proxy-only mode. If null in bootstrap mode, a new resource group is created."
+  default     = null
+}
+
+variable "networking_resource_group" {
+  type        = string
+  description = "Resource group name where the existing VNet and subnet reside. Required when using existing networking (vnet_name/subnet_name) and the networking lives in a different resource group. Defaults to resource_group if not set."
   default     = null
 }
 
@@ -51,7 +57,7 @@ variable "deployment_mode" {
 }
 
 variable "vnet_name" {
-  description = "Name of existing VNet. If null in bootstrap mode, a new VNet is created. Requires resource_group to be set."
+  description = "Name of existing VNet. If null in bootstrap mode, a new VNet is created. Requires resource_group or networking_resource_group to be set."
   type        = string
   default     = null
   validation {
@@ -59,8 +65,8 @@ variable "vnet_name" {
     error_message = "When vnet_name is set, subnet_name must also be provided."
   }
   validation {
-    condition     = var.vnet_name == null || var.resource_group != null
-    error_message = "When vnet_name is set, resource_group must also be provided to look up the existing VNet and subnet."
+    condition     = var.vnet_name == null || var.resource_group != null || var.networking_resource_group != null
+    error_message = "When vnet_name is set, resource_group or networking_resource_group must also be provided to look up the existing VNet and subnet."
   }
 }
 
@@ -71,7 +77,7 @@ variable "vnet_cidr" {
 }
 
 variable "subnet_name" {
-  description = "Name of existing subnet. If null in bootstrap mode, a new subnet is created. Requires vnet_name and resource_group to be set."
+  description = "Name of existing subnet. If null in bootstrap mode, a new subnet is created. Requires vnet_name and resource_group or networking_resource_group to be set."
   type        = string
   default     = null
 }


### PR DESCRIPTION
  ## Summary
  - Adds `networking_resource_group` variable to the Azure module, allowing users to specify a separate resource group for existing VNet/subnet lookups
  - Enables scenarios where networking and proxy resources live in different resource groups (e.g. centralized networking RG + dedicated proxy RG)
  - Defaults to `resource_group` when not set, maintaining full backward compatibility
  - Updates validations, variable descriptions, and documentation (global + Azure README)
  
  feature enhancement based on discussion on issue [#4](https://github.com/databricks-solutions/dbx-proxy/issues/4)

  ## Test plan
  - [ ] Bootstrap mode (no existing networking) — should create new RG and networking as before
  - [ ] Existing networking with `resource_group` only — should use it for subnet lookup (backward compatible)
  - [ ] Existing networking with `networking_resource_group` set — should use it for subnet lookup
  - [ ] Existing networking with both `resource_group` and `networking_resource_group` — proxy resources in `resource_group`, subnet lookup in `networking_resource_group`
  - [ ] Proxy-only mode with `networking_resource_group` — should use it for subnet lookup