### PR TITLE
Supply Chain hardening

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Verify Docker and Docker Compose are available
         run: |
@@ -37,16 +37,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build proxy image (multi-platform, no push)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: docker/proxy.Dockerfile

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,18 +22,18 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -53,7 +53,7 @@ jobs:
           echo "SHORT_SHA=${SHORT_SHA}" >> "$GITHUB_ENV"
 
       - name: Build and push proxy image (multi-platform)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: docker/proxy.Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,8 @@ terraform/**/.tfvars
 **/.terraform.lock.hcl
 **/terraform*.tfstate
 **/terraform*.backup
+
+# ai
+.claude
+.isaac
+.superpowers

--- a/CODEOWNERS.txt
+++ b/CODEOWNERS.txt
@@ -1,0 +1,2 @@
+# Default code owner for dbx-proxy repository
+*   @dnks0

--- a/docker/proxy.Dockerfile
+++ b/docker/proxy.Dockerfile
@@ -1,5 +1,6 @@
 ARG HAPROXY_VERSION=3.3.0
-FROM haproxy:$HAPROXY_VERSION
+# Pinned to the digest of haproxy:3.3.0 for supply-chain integrity; tag kept for readability: 3.3.0
+FROM haproxy:$HAPROXY_VERSION@sha256:b15d4d6722360dc363501c29f089b37327489c1a9439479da126066d2a47935f
 
 # go root to copy files, create the necessary directories
 # and then switch back to non-root.

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.12-slim
+# Pinned to the digest of python:3.12-slim for supply-chain integrity; tag kept for readability: 3.12-slim
+FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 
 WORKDIR /tests
 RUN mkdir -p /tests/unit_tests

--- a/tests/docker/backends/backend.Dockerfile
+++ b/tests/docker/backends/backend.Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.12-slim
+# Pinned to the digest of python:3.12-slim for supply-chain integrity; tag kept for readability: 3.12-slim
+FROM python:3.12-slim@sha256:57cd7c3a7a273101a6485ba99423ee568157882804b1124b4dd04266317710de
 
 WORKDIR /app
 

--- a/tests/docker/render-config/Dockerfile
+++ b/tests/docker/render-config/Dockerfile
@@ -1,4 +1,5 @@
-FROM hashicorp/terraform:1.14.3
+# Pinned to the digest of hashicorp/terraform:1.14.3 for supply-chain integrity; tag kept for readability: 1.14.3
+FROM hashicorp/terraform:1.14.3@sha256:20056ea0d2706f2a944e202befa8a558dbcc5798da0b64f884b2647aab82a4ef
 
 # Used to robustly extract the cfg from `terraform show -json` without brittle heredoc parsing.
 RUN apk add --no-cache jq


### PR DESCRIPTION
Replace mutable version tags with immutable digests so a re-tagged or compromised upstream can't silently change builds.