### PR TITLE
ci: add Dependabot config, PR-triggered build, and release environmen…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,47 @@
+version: 2
+updates:
+  # Keep GitHub Actions (SHA-pinned) up to date.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    # Bundle minor + patch bumps into one PR; major bumps still open
+    # individually so breaking changes get reviewed in isolation.
+    groups:
+      actions-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  # Keep Docker base images up to date across all Dockerfiles
+  # (docker/, tests/docker/, tests/docker/render-config/).
+  - package-ecosystem: "docker"
+    directories:
+      - "**/*"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    # Bundle minor + patch bumps into one PR; major bumps still open
+    # individually so breaking changes get reviewed in isolation.
+    groups:
+      docker-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "docker"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,8 @@ env:
 jobs:
   docker-deploy:
     runs-on: ubuntu-latest
+    # Publishing is gated on the "release" environment.
+    environment: release
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
…t gate

- Add .github/dependabot.yml with weekly grouped updates for github-actions and docker (minor+patch bundled, major bumps open individually)
- build.yml: run on pull_request to main so CI covers incoming PRs
- deploy.yml: gate GHCR publish on the "release" environment (required reviewer configured in repo settings)

Co-authored-by: Isaac